### PR TITLE
Add dark theme to desktop app

### DIFF
--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -169,8 +169,12 @@ fun CardPanel(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .width(315.dp)
                     .height(440.dp)
-                    .border(width = 2.dp, color = Color.Black, shape = RoundedCornerShape(10.dp))
-                    .background(color = Color.White)
+                    .border(
+                        width = 2.dp,
+                        color = MaterialTheme.colors.primary,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .background(color = MaterialTheme.colors.surface)
                     .padding(all = 20.dp),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -201,8 +205,18 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     .height(440.dp)
                     .offset { animatedOffset }
                     .rotate(animatedOffset.x / 80.0f)
-                    .border(width = 2.dp, color = Color.Black, shape = RoundedCornerShape(10.dp))
-                    .background(color = animatedColor)
+                    .border(
+                        width = 2.dp,
+                        color = MaterialTheme.colors.primary,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .background(
+                        color = if (animatedColor == Color.Transparent) {
+                            MaterialTheme.colors.surface
+                        } else {
+                            animatedColor
+                        }
+                    )
                     .padding(all = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
@@ -274,6 +288,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                             Icon(
                                 imageVector = Icons.Default.Edit,
                                 contentDescription = "Edit",
+                                tint = MaterialTheme.colors.primary,
                                 modifier = Modifier
                                     .size(24.dp)
                                     .clickable {
@@ -284,6 +299,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = "Delete",
+                                tint = MaterialTheme.colors.error,
                                 modifier = Modifier
                                     .size(24.dp)
                                     .clickable {

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
@@ -79,7 +79,8 @@ fun DeckItem(
                     Icon(
                         imageVector = Icons.Default.Add,
                         contentDescription = "Add Card",
-                        modifier = Modifier.size(14.dp)
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colors.primary
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/theme/AppTheme.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/theme/AppTheme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.Typography
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -12,13 +13,19 @@ import androidx.compose.ui.unit.sp
 import me.forketyfork.welk.fonts.AppFonts
 
 // Colors for the application
-private val primaryColor = Color(0xFF6200EE)
-private val primaryVariant = Color(0xFF3700B3)
-private val secondaryColor = Color(0xFF03DAC5)
-private val secondaryVariant = Color(0xFF018786)
-private val backgroundColor = Color(0xFFF5F5F5)
+// Updated colors with a violet-focused palette
+private val primaryColor = Color(0xFF7C4DFF)
+private val primaryVariant = Color(0xFF651FFF)
+private val secondaryColor = Color(0xFFCE93D8)
+private val secondaryVariant = Color(0xFFAB47BC)
+private val backgroundColor = Color(0xFFF3E5F5)
 private val surfaceColor = Color.White
 private val onSurfaceColor = Color(0xFF121212)
+
+// Dark theme specific colors
+private val darkBackgroundColor = Color(0xFF121212)
+private val darkSurfaceColor = Color(0xFF1E1E1E)
+private val darkOnSurfaceColor = Color.White
 
 // Light theme colors
 private val LightColors = lightColors(
@@ -36,7 +43,10 @@ private val DarkColors = darkColors(
     primary = primaryColor,
     primaryVariant = primaryVariant,
     secondary = secondaryColor,
-    secondaryVariant = secondaryVariant
+    secondaryVariant = secondaryVariant,
+    background = darkBackgroundColor,
+    surface = darkSurfaceColor,
+    onSurface = darkOnSurfaceColor
 )
 
 // Typography settings using our custom fonts
@@ -44,17 +54,17 @@ private val appTypography = Typography(
     h1 = TextStyle(
         fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Bold,
-        fontSize = 28.sp
+        fontSize = 32.sp
     ),
     h2 = TextStyle(
         fontFamily = AppFonts.openSans,
-        fontWeight = FontWeight.Bold,
-        fontSize = 24.sp
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 26.sp
     ),
     h3 = TextStyle(
         fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 20.sp
+        fontSize = 22.sp
     ),
     h4 = TextStyle(
         fontFamily = AppFonts.openSans,
@@ -72,28 +82,34 @@ private val appTypography = Typography(
         fontSize = 14.sp
     ),
     body1 = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp
     ),
     body2 = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp
     ),
     button = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp
+    ),
+    caption = TextStyle(
+        fontFamily = AppFonts.openSans,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp
     )
 )
 
 @Composable
 fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
     MaterialTheme(
-        colors = LightColors,
+        colors = if (darkTheme) DarkColors else LightColors,
         typography = appTypography,
         content = content
     )


### PR DESCRIPTION
## Summary
- introduce dark theme colors and automatic theme switching
- surface backgrounds adapt to theme for card panels

## Testing
- `./gradlew :composeApp:build` *(fails: No route to host)*