### PR TITLE
Fix dark mode visuals

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,9 @@ compose.desktop {
             packageVersion = "1.0.0"
             macOS {
                 iconFile.set(project.file("welk_icon.icns"))
+                jvmArgs(
+                    "-Dapple.awt.application.appearance=system"
+                )
             }
         }
     }

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/App.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/App.kt
@@ -1,5 +1,6 @@
 package me.forketyfork.welk
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.material.MaterialTheme
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.forketyfork.welk.components.CardPanel
@@ -35,13 +37,22 @@ fun App(module: Module = appModule) {
         AppTheme {
             if (userId.value == null) {
                 // show the login screen
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colors.background),
+                    contentAlignment = Alignment.Center
+                ) {
                     LoginView()
                 }
             } else {
                 // show the main application screen
                 // Use Box as parent to manage z-index
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colors.background)
+                ) {
                     // Use Row for the layout
                     Row(modifier = Modifier.fillMaxSize()) {
                         // Left panel with the app name and deck list with fixed width

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -25,7 +25,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TextFieldColors
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -25,6 +25,8 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -185,6 +187,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     "No cards in this deck",
                     style = TextStyle(fontSize = 18.sp),
                     textAlign = TextAlign.Center,
+                    color = MaterialTheme.colors.onSurface
                 )
                 Spacer(modifier = Modifier.height(20.dp))
                 Button(
@@ -226,6 +229,9 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     // Edit mode UI
                     OutlinedTextField(
                         value = frontText,
+                        colors = TextFieldDefaults.textFieldColors(
+                            textColor = MaterialTheme.colors.onSurface
+                        ),
                         onValueChange = { frontText = it },
                         label = { Text("Front") },
                         modifier = Modifier.fillMaxWidth().weight(1f)
@@ -234,6 +240,9 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     Divider()
                     OutlinedTextField(
                         value = backText,
+                        colors = TextFieldDefaults.textFieldColors(
+                            textColor = MaterialTheme.colors.onSurface
+                        ),
                         onValueChange = { backText = it },
                         label = { Text("Back") },
                         modifier = Modifier.fillMaxWidth().weight(1f)
@@ -282,7 +291,8 @@ fun CardPanel(modifier: Modifier = Modifier) {
                         ) {
                         Text(
                             currentCard.value.front,
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(1f),
+                            color = MaterialTheme.colors.onSurface
                         )
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -315,6 +325,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     if (isFlipped.value) {
                         Text(
                             text = currentCard.value.back,
+                            color = MaterialTheme.colors.onSurface,
                             modifier = Modifier.testTag(CardPanelTestTags.VIEW_BACK)
                         )
                     }

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -153,6 +154,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
         // Make sure this panel can gain focus and receives keyboard events
         modifier = modifier
             .fillMaxSize()
+            .background(MaterialTheme.colors.background)
             .testTag(CardPanelTestTags.CARD_PANEL)
             .onKeyEvent { event: KeyEvent ->
                 logger.d { "Card got key event: $event" }
@@ -169,8 +171,12 @@ fun CardPanel(modifier: Modifier = Modifier) {
                 modifier = Modifier
                     .width(315.dp)
                     .height(440.dp)
-                    .border(width = 2.dp, color = Color.Black, shape = RoundedCornerShape(10.dp))
-                    .background(color = Color.White)
+                    .border(
+                        width = 2.dp,
+                        color = MaterialTheme.colors.primary,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .background(color = MaterialTheme.colors.surface)
                     .padding(all = 20.dp),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -201,8 +207,18 @@ fun CardPanel(modifier: Modifier = Modifier) {
                     .height(440.dp)
                     .offset { animatedOffset }
                     .rotate(animatedOffset.x / 80.0f)
-                    .border(width = 2.dp, color = Color.Black, shape = RoundedCornerShape(10.dp))
-                    .background(color = animatedColor)
+                    .border(
+                        width = 2.dp,
+                        color = MaterialTheme.colors.primary,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .background(
+                        color = if (animatedColor == Color.Transparent) {
+                            MaterialTheme.colors.surface
+                        } else {
+                            animatedColor
+                        }
+                    )
                     .padding(all = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
@@ -274,6 +290,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                             Icon(
                                 imageVector = Icons.Default.Edit,
                                 contentDescription = "Edit",
+                                tint = MaterialTheme.colors.primary,
                                 modifier = Modifier
                                     .size(24.dp)
                                     .clickable {
@@ -284,6 +301,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                             Icon(
                                 imageVector = Icons.Default.Delete,
                                 contentDescription = "Delete",
+                                tint = MaterialTheme.colors.error,
                                 modifier = Modifier
                                     .size(24.dp)
                                     .clickable {

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
@@ -79,7 +79,8 @@ fun DeckItem(
                     Icon(
                         imageVector = Icons.Default.Add,
                         contentDescription = "Add Card",
-                        modifier = Modifier.size(14.dp)
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colors.primary
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/LoginView.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/LoginView.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +47,9 @@ fun LoginView() {
         )
         OutlinedTextField(
             value = username,
+            colors = TextFieldDefaults.textFieldColors(
+                textColor = MaterialTheme.colors.onSurface
+            ),
             onValueChange = { username = it },
             label = { Text("Username") },
             singleLine = true,
@@ -54,6 +58,9 @@ fun LoginView() {
         )
         OutlinedTextField(
             value = password,
+            colors = TextFieldDefaults.textFieldColors(
+                textColor = MaterialTheme.colors.onSurface
+            ),
             onValueChange = { password = it },
             label = { Text("Password") },
             singleLine = true,

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/theme/AppTheme.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/theme/AppTheme.kt
@@ -1,5 +1,6 @@
 package me.forketyfork.welk.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Typography
 import androidx.compose.material.darkColors
@@ -12,13 +13,18 @@ import androidx.compose.ui.unit.sp
 import me.forketyfork.welk.fonts.AppFonts
 
 // Colors for the application
-private val primaryColor = Color(0xFF6200EE)
-private val primaryVariant = Color(0xFF3700B3)
-private val secondaryColor = Color(0xFF03DAC5)
-private val secondaryVariant = Color(0xFF018786)
-private val backgroundColor = Color(0xFFF5F5F5)
-private val surfaceColor = Color.White
-private val onSurfaceColor = Color(0xFF121212)
+// Updated colors with a violet-focused palette
+private val primaryColor = Color(0xFF7C4DFF)
+private val primaryVariant = Color(0xFF651FFF)
+private val secondaryColor = Color(0xFFCE93D8)
+private val secondaryVariant = Color(0xFFAB47BC)
+private val backgroundColorLight = Color(0xFFF3E5F5)
+private val surfaceColorLight = Color.White
+private val onSurfaceColorLight = Color(0xFF121212)
+
+private val backgroundColorDark = Color(0xFF121212)
+private val surfaceColorDark = Color(0xFF1E1E1E)
+private val onSurfaceColorDark = Color.White
 
 // Light theme colors
 private val LightColors = lightColors(
@@ -26,17 +32,19 @@ private val LightColors = lightColors(
     primaryVariant = primaryVariant,
     secondary = secondaryColor,
     secondaryVariant = secondaryVariant,
-    background = backgroundColor,
-    surface = surfaceColor,
-    onSurface = onSurfaceColor
+    background = backgroundColorLight,
+    surface = surfaceColorLight,
+    onSurface = onSurfaceColorLight
 )
 
-// Dark theme colors - not used yet but prepared for future
 private val DarkColors = darkColors(
     primary = primaryColor,
     primaryVariant = primaryVariant,
     secondary = secondaryColor,
-    secondaryVariant = secondaryVariant
+    secondaryVariant = secondaryVariant,
+    background = backgroundColorDark,
+    surface = surfaceColorDark,
+    onSurface = onSurfaceColorDark
 )
 
 // Typography settings using our custom fonts
@@ -44,17 +52,17 @@ private val appTypography = Typography(
     h1 = TextStyle(
         fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Bold,
-        fontSize = 28.sp
+        fontSize = 32.sp
     ),
     h2 = TextStyle(
         fontFamily = AppFonts.openSans,
-        fontWeight = FontWeight.Bold,
-        fontSize = 24.sp
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 26.sp
     ),
     h3 = TextStyle(
         fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.SemiBold,
-        fontSize = 20.sp
+        fontSize = 22.sp
     ),
     h4 = TextStyle(
         fontFamily = AppFonts.openSans,
@@ -72,19 +80,24 @@ private val appTypography = Typography(
         fontSize = 14.sp
     ),
     body1 = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp
     ),
     body2 = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp
     ),
     button = TextStyle(
-        fontFamily = AppFonts.roboto,
+        fontFamily = AppFonts.openSans,
         fontWeight = FontWeight.Medium,
         fontSize = 14.sp
+    ),
+    caption = TextStyle(
+        fontFamily = AppFonts.openSans,
+        fontWeight = FontWeight.Normal,
+        fontSize = 12.sp
     )
 )
 
@@ -92,8 +105,10 @@ private val appTypography = Typography(
 fun AppTheme(
     content: @Composable () -> Unit
 ) {
+    val darkTheme = isSystemInDarkTheme()
+
     MaterialTheme(
-        colors = LightColors,
+        colors = if (darkTheme) DarkColors else LightColors,
         typography = appTypography,
         content = content
     )


### PR DESCRIPTION
## Summary
- switch `AppTheme` between light and dark palettes based on `isSystemInDarkTheme`
- ensure card panel and login screen use theme backgrounds
- use theme surfaces for card backgrounds
- add missing `MaterialTheme` import

## Testing
- `./gradlew :composeApp:build` *(fails: No route to host)*