### PR TITLE
Auto focus first field of forms

### DIFF
--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -78,6 +78,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
     }
 
     val focusRequester = remember { FocusRequester() }
+    val editFrontFocusRequester = remember { FocusRequester() }
 
     val currentDeck = cardViewModel.currentDeck.collectAsStateWithLifecycle()
     val hasCards = remember(currentDeck.value?.value) {
@@ -95,6 +96,12 @@ fun CardPanel(modifier: Modifier = Modifier) {
         // Check if we have a deck and either have cards or are in edit mode
         if (currentDeck.value != null && (hasCards.value || isEditing.value)) {
             focusRequester.requestFocus()
+        }
+    }
+
+    LaunchedEffect(isEditing.value) {
+        if (isEditing.value) {
+            editFrontFocusRequester.requestFocus()
         }
     }
 
@@ -213,6 +220,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                             onValueChange = { frontText = it },
                             label = { Text("Front") },
                             modifier = Modifier.fillMaxWidth().weight(1f)
+                                .focusRequester(editFrontFocusRequester)
                                 .testTag(CardPanelTestTags.EDIT_FRONT)
                         .moveFocusOnTab())
                         Divider()

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -54,8 +56,8 @@ fun CardPanel(modifier: Modifier = Modifier) {
     val isDeleteConfirmationShowing =
         cardViewModel.isDeleteConfirmationShowing.collectAsStateWithLifecycle()
 
-    var frontText by remember { mutableStateOf("") }
-    var backText by remember { mutableStateOf("") }
+    var frontText by remember { mutableStateOf(TextFieldValue("")) }
+    var backText by remember { mutableStateOf(TextFieldValue("")) }
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -68,12 +70,12 @@ fun CardPanel(modifier: Modifier = Modifier) {
         // Only update the text values if we're in edit mode
         if (isEditing.value) {
             val (front, back) = editCardContent.value
-            frontText = front
-            backText = back
+            frontText = TextFieldValue(front, TextRange(front.length))
+            backText = TextFieldValue(back, TextRange(back.length))
         } else {
             // Clear the fields when exiting edit mode
-            frontText = ""
-            backText = ""
+            frontText = TextFieldValue("")
+            backText = TextFieldValue("")
         }
     }
 
@@ -241,7 +243,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                         ) {
                             Button(
                                 onClick = {
-                                    cardViewModel.updateEditContent(frontText, backText)
+                                    cardViewModel.updateEditContent(frontText.text, backText.text)
                                     coroutineScope.launch {
                                         // First save the edits to update the card content
                                         cardViewModel.saveCardEdit()

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/LoginView.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/LoginView.kt
@@ -9,12 +9,15 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -34,7 +37,12 @@ fun LoginView() {
 
     var username by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    val usernameFocusRequester = remember { FocusRequester() }
     val loginError = viewModel.loginError.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        usernameFocusRequester.requestFocus()
+    }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally
@@ -54,6 +62,7 @@ fun LoginView() {
             label = { Text("Username") },
             singleLine = true,
             modifier = Modifier.width(300.dp)
+                .focusRequester(usernameFocusRequester)
                 .testTag(LoginViewTestTags.USERNAME_INPUT),
         )
         OutlinedTextField(

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -38,7 +40,14 @@ fun SidePanel(
     var showAddDeckDialog by remember { mutableStateOf(false) }
     var newDeckName by remember { mutableStateOf("") }
     var newDeckDescription by remember { mutableStateOf("") }
+    val deckNameFocusRequester = remember { FocusRequester() }
     var deckIdToDelete by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(showAddDeckDialog) {
+        if (showAddDeckDialog) {
+            deckNameFocusRequester.requestFocus()
+        }
+    }
 
     Box(
         modifier = modifier
@@ -163,7 +172,8 @@ fun SidePanel(
                                 value = newDeckName,
                                 onValueChange = { newDeckName = it },
                                 label = { Text("Name") },
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier.fillMaxWidth()
+                                    .focusRequester(deckNameFocusRequester),
                                 singleLine = true,
                             )
                             Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- focus username input when LoginView appears
- focus front text field when editing a card
- focus name field when opening Add Deck dialog

## Testing
- `./gradlew :composeApp:build` *(fails: No route to host)*