### PR TITLE
Add vertical scroll to deck list

### DIFF
--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
@@ -41,6 +41,7 @@ fun SidePanel(
     var newDeckName by remember { mutableStateOf("") }
     var newDeckDescription by remember { mutableStateOf("") }
     var deckIdToDelete by remember { mutableStateOf<String?>(null) }
+    val deckListScrollState = rememberScrollState()
 
     Box(
         modifier = modifier
@@ -82,7 +83,7 @@ fun SidePanel(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(deckListScrollState)
             ) {
                 decks.forEach { deck ->
                     DeckItem(

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
@@ -2,6 +2,8 @@ package me.forketyfork.welk.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
@@ -76,26 +78,29 @@ fun SidePanel(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            // List of decks
-            decks.forEach { deck ->
-                DeckItem(
-                    deck = deck,
-                    isSelected = currentDeck?.value?.id == deck.value.id,
-                    onClick = {
-                        cardViewModel.viewModelScope.launch {
-                            val deckId = deck.value.id ?: error("Deck id is null for a persistent entity")
-                            cardViewModel.selectDeck(deckId)
-                        }
-                    },
-                    onAddCard = { deckId ->
-                        cardViewModel.processAction(CardAction.CreateNewCard(deckId))
-                    },
-                    onDeleteDeck = { id -> deckIdToDelete = id }
-                )
+            // Scrollable list of decks
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                decks.forEach { deck ->
+                    DeckItem(
+                        deck = deck,
+                        isSelected = currentDeck?.value?.id == deck.value.id,
+                        onClick = {
+                            cardViewModel.viewModelScope.launch {
+                                val deckId = deck.value.id ?: error("Deck id is null for a persistent entity")
+                                cardViewModel.selectDeck(deckId)
+                            }
+                        },
+                        onAddCard = { deckId ->
+                            cardViewModel.processAction(CardAction.CreateNewCard(deckId))
+                        },
+                        onDeleteDeck = { id -> deckIdToDelete = id }
+                    )
+                }
             }
-
-            // Spacer that pushes the bottom panel to the bottom
-            Spacer(modifier = Modifier.weight(1f))
 
             // Bottom panel with actions
             Divider()


### PR DESCRIPTION
## Summary
- add scroll state handling for the deck list
- wrap deck list in a scrollable column

## Testing
- `./gradlew :composeApp:build` *(fails: No route to host)*