### PR TITLE
Introduce deck info panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platfor
     - Card panel with edit/delete functionality
     - Side panel with deck listing and user actions
     - Confirmation dialogs for destructive actions
-    - Bottom panel in side panel with application-wide actions like logout
+    - Bottom panel in the side panel with application-wide actions like logout
 
 4. **Service Layer**
     - `AuthService` - Interface for authentication operations
@@ -208,8 +208,16 @@ Available log levels:
 - If you need to add any Kotlin opt-ins, use file-level annotations
 
 ### Concurrency
-
+- Structure the code using the principles of functional reactive programming.
+- Reuse existing flows to derive state using Kotlin's flow operations instead of creating new flows.
 - Implement the reactive code using Kotlin's `StateFlow`, do not rely on the Android specific
   reactive features.
 - Avoid calling `delay()` or `Thread.sleep()` to wait for obscure racy conditions, even in tests.
   Always implement proper reactive patterns to react on the exact condition.
+
+### Comments
+
+- Write useful, accessible and grammatically correct comments. 
+- Avoid words or phrases that may be hard to comprehend.
+- When writing comments, don't explain obvious things or duplicate what's already visible from the code.
+  Try to focus on complicated parts or intentions that may not be clear from the code itself. 

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -89,6 +89,8 @@ fun CardPanel(modifier: Modifier = Modifier) {
         }
     }
 
+    val learnedCardCount = cardViewModel.learnedCardCount.collectAsStateWithLifecycle()
+
     // Only request focus when we have cards or there's a deck selected
     LaunchedEffect(
         currentCard.value,
@@ -138,8 +140,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
         )
     }
 
-    Box(
-        // Make sure this panel can gain focus and receives keyboard events
+    Column(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colors.background)
@@ -150,10 +151,13 @@ fun CardPanel(modifier: Modifier = Modifier) {
                 cardViewModel.processAction(action)
             }
             .focusRequester(focusRequester)
-            .focusable(),
-        contentAlignment = Alignment.Center
+            .focusable()
     ) {
-        if (currentDeck.value != null) {
+        Box(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            if (currentDeck.value != null) {
             if (!hasCards.value && !isEditing.value) {
                 // Show a message when there are no cards in the deck
                 Column(
@@ -325,6 +329,10 @@ fun CardPanel(modifier: Modifier = Modifier) {
             }
         }
     }
+
+        currentDeck.value?.value?.let { deck ->
+            DeckInfoPanel(deck, learnedCardCount.value)
+        }
 }
 
 object CardPanelTestTags {
@@ -338,6 +346,7 @@ object CardPanelTestTags {
     const val CREATE_FIRST_CARD_BUTTON = "create_first_card_button"
     const val CARD_PANEL = "card_panel"
     const val CONFIRM_DELETE_BUTTON = "confirm_delete_button"
+    const val DECK_INFO_PANEL = "deck_info_panel"
 }
 
 // For multiline fields, Tab doesn't work as expected, so we need to move focus manually

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -39,19 +39,6 @@ import me.forketyfork.welk.vm.DesktopCardViewModel
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
-object CardPanelTestTags {
-    const val VIEW_BACK = "card_view_back"
-    const val EDIT_FRONT = "card_edit_front"
-    const val EDIT_BACK = "card_edit_back"
-    const val EDIT_SAVE = "card_edit_save_button"
-    const val EDIT_CANCEL = "card_edit_cancel_button"
-    const val EDIT_BUTTON = "card_edit_button"
-    const val DELETE_BUTTON = "card_delete_button"
-    const val CREATE_FIRST_CARD_BUTTON = "create_first_card_button"
-    const val CARD_PANEL = "card_panel"
-    const val CONFIRM_DELETE_BUTTON = "confirm_delete_button"
-}
-
 private val logger = Logger.withTag("CardPanel")
 
 @Composable
@@ -365,4 +352,17 @@ fun Modifier.moveFocusOnTab() = composed {
             false
         }
     }
+}
+
+object CardPanelTestTags {
+    const val VIEW_BACK = "card_view_back"
+    const val EDIT_FRONT = "card_edit_front"
+    const val EDIT_BACK = "card_edit_back"
+    const val EDIT_SAVE = "card_edit_save_button"
+    const val EDIT_CANCEL = "card_edit_cancel_button"
+    const val EDIT_BUTTON = "card_edit_button"
+    const val DELETE_BUTTON = "card_delete_button"
+    const val CREATE_FIRST_CARD_BUTTON = "create_first_card_button"
+    const val CARD_PANEL = "card_panel"
+    const val CONFIRM_DELETE_BUTTON = "confirm_delete_button"
 }

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -61,7 +61,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
 
     val coroutineScope = rememberCoroutineScope()
 
-    // Update local state when edit mode is activated or when creating a new card
+    // Update the local state when edit mode is activated or when creating a new card
     LaunchedEffect(
         editCardContent.value,
         isEditing.value,
@@ -250,7 +250,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
                                     onClick = {
                                         cardViewModel.updateEditContent(frontText.text, backText.text)
                                         coroutineScope.launch {
-                                            // First save the edits to update the card content
+                                            // First, save the edits to update the card content
                                             cardViewModel.saveCardEdit()
                                             // Then exit edit mode
                                             cardViewModel.processAction(CardAction.SaveEdit)

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -39,6 +39,19 @@ import me.forketyfork.welk.vm.DesktopCardViewModel
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
+object CardPanelTestTags {
+    const val VIEW_BACK = "card_view_back"
+    const val EDIT_FRONT = "card_edit_front"
+    const val EDIT_BACK = "card_edit_back"
+    const val EDIT_SAVE = "card_edit_save_button"
+    const val EDIT_CANCEL = "card_edit_cancel_button"
+    const val EDIT_BUTTON = "card_edit_button"
+    const val DELETE_BUTTON = "card_delete_button"
+    const val CREATE_FIRST_CARD_BUTTON = "create_first_card_button"
+    const val CARD_PANEL = "card_panel"
+    const val CONFIRM_DELETE_BUTTON = "confirm_delete_button"
+}
+
 private val logger = Logger.withTag("CardPanel")
 
 @Composable
@@ -158,195 +171,183 @@ fun CardPanel(modifier: Modifier = Modifier) {
             contentAlignment = Alignment.Center
         ) {
             if (currentDeck.value != null) {
-            if (!hasCards.value && !isEditing.value) {
-                // Show a message when there are no cards in the deck
-                Column(
-                    modifier = Modifier
-                        .width(315.dp)
-                        .height(440.dp)
-                        .border(
-                            width = 2.dp,
-                            color = MaterialTheme.colors.primary,
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .background(color = MaterialTheme.colors.background)
-                        .padding(all = 20.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        "No cards in this deck",
-                        style = TextStyle(fontSize = 18.sp),
-                        textAlign = TextAlign.Center,
-                        color = MaterialTheme.colors.onSurface
-                    )
-                    Spacer(modifier = Modifier.height(20.dp))
-                    Button(
-                        onClick = {
-                            val currentDeck = cardViewModel.currentDeck.value
-                            if (currentDeck != null) {
-                                cardViewModel.processAction(CardAction.CreateNewCardInCurrentDeck)
-                            }
-                        },
-                        modifier = Modifier.testTag(CardPanelTestTags.CREATE_FIRST_CARD_BUTTON)
+                if (!hasCards.value && !isEditing.value) {
+                    // Show a message when there are no cards in the deck
+                    Column(
+                        modifier = Modifier
+                            .width(315.dp)
+                            .height(440.dp)
+                            .border(
+                                width = 2.dp,
+                                color = MaterialTheme.colors.primary,
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .background(color = MaterialTheme.colors.background)
+                            .padding(all = 20.dp),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        Text("Create a Card")
-                    }
-                }
-            } else {
-                // Show the card
-                Column(
-                    modifier = Modifier
-                        .width(315.dp)
-                        .height(440.dp)
-                        .offset { animatedOffset }
-                        .rotate(animatedOffset.x / 80.0f)
-                        .border(
-                            width = 2.dp,
-                            color = MaterialTheme.colors.primary,
-                            shape = RoundedCornerShape(10.dp)
+                        Text(
+                            "No cards in this deck",
+                            style = TextStyle(fontSize = 18.sp),
+                            textAlign = TextAlign.Center,
+                            color = MaterialTheme.colors.onSurface
                         )
-                        .background(
-                            color = if (animatedColor == Color.Transparent) {
-                                MaterialTheme.colors.background
-                            } else {
-                                animatedColor
-                            }
-                        )
-                        .padding(all = 20.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    if (isEditing.value) {
-                        // Edit mode UI
-                        OutlinedTextField(
-                            value = frontText,
-                            colors = TextFieldDefaults.textFieldColors(
-                                textColor = MaterialTheme.colors.onSurface
-                            ),
-                            onValueChange = { frontText = it },
-                            label = { Text("Front") },
-                            modifier = Modifier.fillMaxWidth().weight(1f)
-                                .focusRequester(editFrontFocusRequester)
-                                .testTag(CardPanelTestTags.EDIT_FRONT)
-                        .moveFocusOnTab())
-                        Divider()
-                        OutlinedTextField(
-                            value = backText,
-                            colors = TextFieldDefaults.textFieldColors(
-                                textColor = MaterialTheme.colors.onSurface
-                            ),
-                            onValueChange = { backText = it },
-                            label = { Text("Back") },
-                            modifier = Modifier.fillMaxWidth().weight(1f)
-                                .testTag(CardPanelTestTags.EDIT_BACK).moveFocusOnTab()
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Button(
+                            onClick = {
+                                val currentDeck = cardViewModel.currentDeck.value
+                                if (currentDeck != null) {
+                                    cardViewModel.processAction(CardAction.CreateNewCardInCurrentDeck)
+                                }
+                            },
+                            modifier = Modifier.testTag(CardPanelTestTags.CREATE_FIRST_CARD_BUTTON)
                         ) {
-                            Button(
-                                onClick = {
-                                    cardViewModel.updateEditContent(frontText.text, backText.text)
-                                    coroutineScope.launch {
-                                        // First save the edits to update the card content
-                                        cardViewModel.saveCardEdit()
-                                        // Then exit edit mode
-                                        cardViewModel.processAction(CardAction.SaveEdit)
-                                        // Return focus to the card for keyboard navigation
-                                        focusRequester.requestFocus()
-                                    }
-                                },
-                                modifier = Modifier.testTag(CardPanelTestTags.EDIT_SAVE)
-                            ) {
-                                Text("Save")
-                            }
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Button(
-                                onClick = {
-                                    // Cancel without saving changes and reset to original values
-                                    cardViewModel.processAction(CardAction.CancelEdit)
-                                    // Return focus to the card for keyboard navigation
-                                    focusRequester.requestFocus()
-                                },
-                                modifier = Modifier.testTag(CardPanelTestTags.EDIT_CANCEL)
-                            ) {
-                                Text("Cancel")
-                            }
+                            Text("Create a Card")
                         }
-                    } else {
-                        // Normal view mode UI
-                        val card = currentCard.value
-                        if (card != null) {
+                    }
+                } else {
+                    // Show the card
+                    Column(
+                        modifier = Modifier
+                            .width(315.dp)
+                            .height(440.dp)
+                            .offset { animatedOffset }
+                            .rotate(animatedOffset.x / 80.0f)
+                            .border(
+                                width = 2.dp,
+                                color = MaterialTheme.colors.primary,
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .background(
+                                color = if (animatedColor == Color.Transparent) {
+                                    MaterialTheme.colors.background
+                                } else {
+                                    animatedColor
+                                }
+                            )
+                            .padding(all = 20.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        if (isEditing.value) {
+                            // Edit mode UI
+                            OutlinedTextField(
+                                value = frontText,
+                                colors = TextFieldDefaults.textFieldColors(
+                                    textColor = MaterialTheme.colors.onSurface
+                                ),
+                                onValueChange = { frontText = it },
+                                label = { Text("Front") },
+                                modifier = Modifier.fillMaxWidth().weight(1f)
+                                    .focusRequester(editFrontFocusRequester)
+                                    .testTag(CardPanelTestTags.EDIT_FRONT)
+                                    .moveFocusOnTab()
+                            )
+                            Divider()
+                            OutlinedTextField(
+                                value = backText,
+                                colors = TextFieldDefaults.textFieldColors(
+                                    textColor = MaterialTheme.colors.onSurface
+                                ),
+                                onValueChange = { backText = it },
+                                label = { Text("Back") },
+                                modifier = Modifier.fillMaxWidth().weight(1f)
+                                    .testTag(CardPanelTestTags.EDIT_BACK).moveFocusOnTab()
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
                             Row(
                                 modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-
+                                horizontalArrangement = Arrangement.End
+                            ) {
+                                Button(
+                                    onClick = {
+                                        cardViewModel.updateEditContent(frontText.text, backText.text)
+                                        coroutineScope.launch {
+                                            // First save the edits to update the card content
+                                            cardViewModel.saveCardEdit()
+                                            // Then exit edit mode
+                                            cardViewModel.processAction(CardAction.SaveEdit)
+                                            // Return focus to the card for keyboard navigation
+                                            focusRequester.requestFocus()
+                                        }
+                                    },
+                                    modifier = Modifier.testTag(CardPanelTestTags.EDIT_SAVE)
                                 ) {
-                                Text(
-                                    card.front,
-                                    modifier = Modifier.weight(1f),
-                                    color = MaterialTheme.colors.onSurface
-                                )
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    Text("Save")
+                                }
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Button(
+                                    onClick = {
+                                        // Cancel without saving changes and reset to original values
+                                        cardViewModel.processAction(CardAction.CancelEdit)
+                                        // Return focus to the card for keyboard navigation
+                                        focusRequester.requestFocus()
+                                    },
+                                    modifier = Modifier.testTag(CardPanelTestTags.EDIT_CANCEL)
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = "Edit",
-                                        tint = MaterialTheme.colors.primary,
-                                        modifier = Modifier
-                                            .size(24.dp)
-                                            .clickable {
-                                                cardViewModel.processAction(CardAction.Edit)
-                                            }
-                                            .testTag(CardPanelTestTags.EDIT_BUTTON)
-                                    )
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = "Delete",
-                                        tint = MaterialTheme.colors.error,
-                                        modifier = Modifier
-                                            .size(24.dp)
-                                            .clickable {
-                                                cardViewModel.processAction(CardAction.Delete)
-                                            }
-                                            .testTag(CardPanelTestTags.DELETE_BUTTON)
-                                    )
+                                    Text("Cancel")
                                 }
                             }
-                            Divider()
-                            if (isFlipped.value) {
-                                Text(
-                                    text = card.back,
-                                    color = MaterialTheme.colors.onSurface,
-                                    modifier = Modifier.testTag(CardPanelTestTags.VIEW_BACK)
-                                )
+                        } else {
+                            // Normal view mode UI
+                            val card = currentCard.value
+                            if (card != null) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+
+                                    ) {
+                                    Text(
+                                        card.front,
+                                        modifier = Modifier.weight(1f),
+                                        color = MaterialTheme.colors.onSurface
+                                    )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Edit,
+                                            contentDescription = "Edit",
+                                            tint = MaterialTheme.colors.primary,
+                                            modifier = Modifier
+                                                .size(24.dp)
+                                                .clickable {
+                                                    cardViewModel.processAction(CardAction.Edit)
+                                                }
+                                                .testTag(CardPanelTestTags.EDIT_BUTTON)
+                                        )
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Delete",
+                                            tint = MaterialTheme.colors.error,
+                                            modifier = Modifier
+                                                .size(24.dp)
+                                                .clickable {
+                                                    cardViewModel.processAction(CardAction.Delete)
+                                                }
+                                                .testTag(CardPanelTestTags.DELETE_BUTTON)
+                                        )
+                                    }
+                                }
+                                Divider()
+                                if (isFlipped.value) {
+                                    Text(
+                                        text = card.back,
+                                        color = MaterialTheme.colors.onSurface,
+                                        modifier = Modifier.testTag(CardPanelTestTags.VIEW_BACK)
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
-        }
-    }
 
+        }
         currentDeck.value?.value?.let { deck ->
             DeckInfoPanel(deck, learnedCardCount.value)
         }
-}
-
-object CardPanelTestTags {
-    const val VIEW_BACK = "card_view_back"
-    const val EDIT_FRONT = "card_edit_front"
-    const val EDIT_BACK = "card_edit_back"
-    const val EDIT_SAVE = "card_edit_save_button"
-    const val EDIT_CANCEL = "card_edit_cancel_button"
-    const val EDIT_BUTTON = "card_edit_button"
-    const val DELETE_BUTTON = "card_delete_button"
-    const val CREATE_FIRST_CARD_BUTTON = "create_first_card_button"
-    const val CARD_PANEL = "card_panel"
-    const val CONFIRM_DELETE_BUTTON = "confirm_delete_button"
-    const val DECK_INFO_PANEL = "deck_info_panel"
+    }
 }
 
 // For multiline fields, Tab doesn't work as expected, so we need to move focus manually

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
@@ -10,10 +10,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import me.forketyfork.welk.domain.Deck
 
-object DeckInfoPanelTestTags {
-    const val DECK_INFO_PANEL = "deck_info_panel"
-}
-
 @Composable
 fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) {
     Column(
@@ -38,4 +34,8 @@ fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) 
             color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
         )
     }
+}
+
+object DeckInfoPanelTestTags {
+    const val DECK_INFO_PANEL = "deck_info_panel"
 }

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
@@ -1,0 +1,37 @@
+package me.forketyfork.welk.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import me.forketyfork.welk.domain.Deck
+
+@Composable
+fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .testTag(CardPanelTestTags.DECK_INFO_PANEL)
+    ) {
+        Divider()
+        Spacer(modifier = Modifier.height(8.dp))
+        if (deck.description.isNotEmpty()) {
+            Text(
+                deck.description,
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+        Text(
+            "${deck.cardCount} cards, $learnedCount learned",
+            style = MaterialTheme.typography.caption,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
@@ -10,13 +10,17 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import me.forketyfork.welk.domain.Deck
 
+object DeckInfoPanelTestTags {
+    const val DECK_INFO_PANEL = "deck_info_panel"
+}
+
 @Composable
 fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp)
-            .testTag(CardPanelTestTags.DECK_INFO_PANEL)
+            .testTag(DeckInfoPanelTestTags.DECK_INFO_PANEL)
     ) {
         Divider()
         Spacer(modifier = Modifier.height(8.dp))

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
@@ -48,15 +48,6 @@ fun DeckItem(
             modifier = Modifier.align(Alignment.TopEnd),
             horizontalAlignment = Alignment.End
         ) {
-            // Card count
-            Text(
-                text = "${deck.cardCount} cards",
-                style = MaterialTheme.typography.caption,
-                color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f)
-            )
-
-            // Spacer between count and add button
-            Spacer(modifier = Modifier.height(4.dp))
 
             // Add card button
             TextButton(
@@ -128,14 +119,6 @@ fun DeckItem(
                 style = MaterialTheme.typography.body1,
                 color = if (isSelected) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface,
             )
-            if (deck.description.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = deck.description,
-                    style = MaterialTheme.typography.body2,
-                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
-                )
-            }
         }
     }
 }

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckItem.kt
@@ -49,7 +49,7 @@ fun DeckItem(
             horizontalAlignment = Alignment.End
         ) {
 
-            // Add card button
+            // "Add card" button
             TextButton(
                 onClick = {
                     val deckId = deck.id ?: error("Deck id is null for a persistent entity")

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CardInteractionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CardInteractionTest.kt
@@ -35,13 +35,13 @@ class CardInteractionTest : KoinTest {
         verifyBasicUiElements()
 
         // wait until the decks are loaded, verify their expected contents
-        val preloadedDeckIdsAndTexts = mapOf(
-            "deck1" to arrayOf("3 cards", "Basic Vocabulary", "Essential words for beginners"),
-            "deck2" to arrayOf("2 cards", "Grammar Rules", "Key grammar concepts"),
-            "deck3" to arrayOf("2 cards", "Idioms", "Common expressions and idioms")
+        val preloadedDecks = mapOf(
+            "deck1" to "Basic Vocabulary",
+            "deck2" to "Grammar Rules",
+            "deck3" to "Idioms"
         )
 
-        preloadedDeckIdsAndTexts.forEach { (deckId, texts) ->
+        preloadedDecks.forEach { (deckId, name) ->
             waitUntilExactlyOneExists(
                 hasTestTag(DeckItemTestTags.DECK_NAME_TEMPLATE.format(deckId)),
                 timeoutMillis = 10000
@@ -50,8 +50,7 @@ class CardInteractionTest : KoinTest {
                 hasTestTag(DeckItemTestTags.ADD_CARD_BUTTON_TEMPLATE.format(deckId)),
                 timeoutMillis = 10000
             )
-
-            waitUntilExactlyOneExists(hasTextExactly(*texts))
+            waitUntilExactlyOneExists(hasTextExactly(name))
         }
 
         // wait until the first deck is selected and the card is loaded

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CardInteractionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CardInteractionTest.kt
@@ -4,17 +4,7 @@ package me.forketyfork.welk
 
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasTextExactly
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.performKeyInput
-import androidx.compose.ui.test.pressKey
-import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.waitUntilDoesNotExist
-import androidx.compose.ui.test.waitUntilExactlyOneExists
+import androidx.compose.ui.test.*
 import me.forketyfork.welk.components.CardPanelTestTags
 import me.forketyfork.welk.components.DeckItemTestTags
 import org.junit.Test

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CreateNewCardTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CreateNewCardTest.kt
@@ -22,13 +22,13 @@ class CreateNewCardTest : KoinTest {
         verifyBasicUiElements()
 
         // wait until the decks are loaded, verify their expected contents
-        val preloadedDeckIdsAndTexts = mapOf(
-            "deck1" to arrayOf("3 cards", "Basic Vocabulary", "Essential words for beginners"),
-            "deck2" to arrayOf("2 cards", "Grammar Rules", "Key grammar concepts"),
-            "deck3" to arrayOf("2 cards", "Idioms", "Common expressions and idioms")
+        val preloadedDecks = mapOf(
+            "deck1" to "Basic Vocabulary",
+            "deck2" to "Grammar Rules",
+            "deck3" to "Idioms"
         )
 
-        preloadedDeckIdsAndTexts.forEach { (deckId, texts) ->
+        preloadedDecks.forEach { (deckId, name) ->
             waitUntilExactlyOneExists(
                 hasTestTag(DeckItemTestTags.DECK_NAME_TEMPLATE.format(deckId)),
                 timeoutMillis = 10000
@@ -37,8 +37,7 @@ class CreateNewCardTest : KoinTest {
                 hasTestTag(DeckItemTestTags.ADD_CARD_BUTTON_TEMPLATE.format(deckId)),
                 timeoutMillis = 10000
             )
-
-            waitUntilExactlyOneExists(hasTextExactly(*texts))
+            waitUntilExactlyOneExists(hasTextExactly(name))
         }
 
         // add a new card to the first deck
@@ -65,7 +64,8 @@ class CreateNewCardTest : KoinTest {
         waitUntilExactlyOneExists(hasTextExactly("New Back Text"))
 
         // verify that the number of cards bumped to 4
-        waitUntilExactlyOneExists(hasTextExactly("4 cards", "Basic Vocabulary", "Essential words for beginners"))
+        waitUntilExactlyOneExists(hasTextExactly("4 cards, 0 learned"))
+        waitUntilExactlyOneExists(hasTextExactly("Essential words for beginners"))
 
         // delete the card
         onNodeWithTag(CardPanelTestTags.DELETE_BUTTON).performClick()
@@ -73,7 +73,7 @@ class CreateNewCardTest : KoinTest {
         onNodeWithTag(CardPanelTestTags.CONFIRM_DELETE_BUTTON).performClick()
 
         // the number of cards is back to 3
-        waitUntilExactlyOneExists(hasTextExactly("3 cards", "Basic Vocabulary", "Essential words for beginners"))
+        waitUntilExactlyOneExists(hasTextExactly("3 cards, 0 learned"))
 
         // Log out
         logout()

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CreateNewCardTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/CreateNewCardTest.kt
@@ -45,10 +45,10 @@ class CreateNewCardTest : KoinTest {
 
         waitUntilExactlyOneExists(hasTestTag(CardPanelTestTags.EDIT_FRONT))
 
-        // Enter front text of the new card
+        // Enter the front text of the new card
         onNodeWithTag(CardPanelTestTags.EDIT_FRONT).performTextInput("New Front Text")
 
-        // Enter back text of the new card
+        // Enter the back text of the new card
         onNodeWithTag(CardPanelTestTags.EDIT_BACK).performTextInput("New Back Text")
 
         // Save the new card

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/DeckManagementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/DeckManagementTest.kt
@@ -25,18 +25,18 @@ class DeckManagementTest : KoinTest {
         verifyBasicUiElements()
 
         // Wait until the initial decks are loaded
-        val preloadedDeckIdsAndTexts = mapOf(
-            "deck1" to arrayOf("3 cards", "Basic Vocabulary", "Essential words for beginners"),
-            "deck2" to arrayOf("2 cards", "Grammar Rules", "Key grammar concepts"),
-            "deck3" to arrayOf("2 cards", "Idioms", "Common expressions and idioms")
+        val preloadedDecks = mapOf(
+            "deck1" to "Basic Vocabulary",
+            "deck2" to "Grammar Rules",
+            "deck3" to "Idioms"
         )
 
-        preloadedDeckIdsAndTexts.forEach { (deckId, texts) ->
+        preloadedDecks.forEach { (deckId, name) ->
             waitUntilExactlyOneExists(
                 hasTestTag(DeckItemTestTags.DECK_NAME_TEMPLATE.format(deckId)),
                 timeoutMillis = 10000
             )
-            waitUntilExactlyOneExists(hasTextExactly(*texts))
+            waitUntilExactlyOneExists(hasTextExactly(name))
         }
 
         // Click the add deck button
@@ -53,8 +53,8 @@ class DeckManagementTest : KoinTest {
         // Save the new deck
         onNodeWithTag(SidePanelTestTags.SAVE_DECK_BUTTON).performClick()
 
-        // Wait for the new deck to appear and verify its contents
-        waitUntilExactlyOneExists(hasTextExactly("0 cards", "Test Deck", "A test deck for verification"))
+        // Wait for the new deck to appear
+        waitUntilExactlyOneExists(hasTextExactly("Test Deck"))
 
         // Obtain the newly created deck id from its test tag
         val newDeckId = getDeckIdByName("Test Deck")
@@ -83,7 +83,8 @@ class DeckManagementTest : KoinTest {
         waitUntilExactlyOneExists(hasTextExactly("Test Front"))
 
         // Verify that the deck now shows 1 card
-        waitUntilExactlyOneExists(hasTextExactly("1 cards", "Test Deck", "A test deck for verification"))
+        waitUntilExactlyOneExists(hasTextExactly("1 cards, 0 learned"))
+        waitUntilExactlyOneExists(hasTextExactly("A test deck for verification"))
 
         // Delete the deck via the delete button tagged with the deck id
         onNodeWithTag(DeckItemTestTags.DELETE_DECK_BUTTON_TEMPLATE.format(newDeckId)).performClick()
@@ -93,15 +94,15 @@ class DeckManagementTest : KoinTest {
         onNodeWithTag(SidePanelTestTags.CONFIRM_DELETE_BUTTON).performClick()
 
         // Verify that the deck is no longer visible
-        waitUntilDoesNotExist(hasTextExactly("1 cards", "Test Deck", "A test deck for verification"))
+        waitUntilDoesNotExist(hasTextExactly("Test Deck"))
 
         // Verify that we're back to the original 3 decks
-        preloadedDeckIdsAndTexts.forEach { (deckId, texts) ->
+        preloadedDecks.forEach { (deckId, name) ->
             waitUntilExactlyOneExists(
                 hasTestTag(DeckItemTestTags.DECK_NAME_TEMPLATE.format(deckId)),
                 timeoutMillis = 5000
             )
-            waitUntilExactlyOneExists(hasTextExactly(*texts))
+            waitUntilExactlyOneExists(hasTextExactly(name))
         }
 
         // Log out

--- a/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/DeckManagementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/me/forketyfork/welk/DeckManagementTest.kt
@@ -39,7 +39,7 @@ class DeckManagementTest : KoinTest {
             waitUntilExactlyOneExists(hasTextExactly(name))
         }
 
-        // Click the add deck button
+        // Click the "Add deck" button
         onNodeWithTag(SidePanelTestTags.ADD_DECK_BUTTON).performClick()
 
         // wait until the new deck dialog opens
@@ -56,7 +56,7 @@ class DeckManagementTest : KoinTest {
         // Wait for the new deck to appear
         waitUntilExactlyOneExists(hasTextExactly("Test Deck"))
 
-        // Obtain the newly created deck id from its test tag
+        // Get the newly created deck id from its test tag
         val newDeckId = getDeckIdByName("Test Deck")
 
         // Select the new deck
@@ -70,10 +70,10 @@ class DeckManagementTest : KoinTest {
 
         waitUntilExactlyOneExists(hasTestTag(CardPanelTestTags.EDIT_FRONT))
 
-        // Enter front text of the new card
+        // Enter the front text of the new card
         onNodeWithTag(CardPanelTestTags.EDIT_FRONT).performTextInput("Test Front")
 
-        // Enter back text of the new card
+        // Enter the back text of the new card
         onNodeWithTag(CardPanelTestTags.EDIT_BACK).performTextInput("Test Back")
 
         // Save the new card

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
@@ -14,6 +14,7 @@ interface CardViewModel : InitializableViewModel {
     val availableDecks: StateFlow<List<StateFlow<Deck>>>
     val isNewCard: StateFlow<Boolean>
     val isDeleteConfirmationShowing: StateFlow<Boolean>
+    val learnedCardCount: StateFlow<Int>
 
     fun flipCard()
     suspend fun nextCard()

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
@@ -61,7 +61,7 @@ open class SharedCardViewModel(
         _isDeleteConfirmationShowing.asStateFlow()
 
     /**
-     * Starts collection of card position change events, e.g., when we select a new deck,
+     * Starts collecting of card position change events, e.g., when we select a new deck,
      * and the position resets to 0. Updates the UI accordingly.
      */
     private suspend fun collectCurrentCardPositionChanges() {
@@ -75,7 +75,7 @@ open class SharedCardViewModel(
      * deck, and we need to switch the card view.
      */
     private suspend fun collectCurrentDeckChanges() {
-        // When deck changes, load its cards
+        // When the deck changes, load its cards
         _currentDeck.collect { deck ->
             logger.d { "Current deck changed to ${deck?.value?.name}" }
             if (deck != null) {
@@ -158,9 +158,9 @@ open class SharedCardViewModel(
     }
 
     /**
-     * Starts the collection of the card animation completion events, when the user swipes the card
-     * to the left or to the right. When the animation completed, we update the card learned status
-     * and the UI accordingly.
+     * Starts the collection of the card animation completion events when the user swipes the card
+     * to the left or to the right.
+     * When the animation is completed, we update the learned status of the card and the UI accordingly.
      */
     private suspend fun collectCardAnimationCompletion() {
         cardAnimationManager.animationCompleteTrigger
@@ -175,7 +175,7 @@ open class SharedCardViewModel(
                     it.learned
                 )
 
-                // Update local card list with new learned status
+                // Update the local card list with the new learned status
                 val idx = _currentCardPosition.value
                 val updatedCards = _currentDeckCards.value.toMutableList()
                 if (idx in updatedCards.indices) {
@@ -205,7 +205,7 @@ open class SharedCardViewModel(
 
                 logger.w("Not saving card with empty content")
                 if (_isNewCard.value) {
-                    // If this is a new card with empty content, just cancel it
+                    // If this is a new card with empty content, cancel it
                     cancelNewCard()
                 }
                 return
@@ -395,7 +395,7 @@ open class SharedCardViewModel(
 
         logger.d { "Created temporary card for deck $deckId" }
 
-        // Set new card state
+        // Set the new card state
         _isNewCard.value = true
 
         // Set the temporary card as the current card
@@ -421,18 +421,18 @@ open class SharedCardViewModel(
             _isEditing.value = false
             _editCardContent.value = Pair("", "")
 
-            // Simply reload the current deck's data
+            // Reload the current deck's data
             val currentDeck = _currentDeck.value?.value
             if (currentDeck != null) {
                 val deckId = currentDeck.id ?: error("Deck ID is null for a persistent deck")
                 logger.d { "Reloading cards for current deck $deckId" }
 
                 try {
-                    // Get fresh cards list from the repository
+                    // Get the fresh cards list from the repository
                     val freshCards = cardRepository.getCardsByDeckId(deckId)
                     logger.d { "Loaded ${freshCards.size} cards for current deck" }
 
-                    // Update the cards list
+                    // Update the list of cards
                     _currentDeckCards.value = freshCards
 
                     // Set position to the first card if available
@@ -502,7 +502,7 @@ open class SharedCardViewModel(
             // Delete the card from the repository
             cardRepository.deleteCard(cardId, card.deckId)
 
-            // Remove from local card list
+            // Remove from the local card list
             val updatedCards = _currentDeckCards.value.toMutableList()
             updatedCards.removeAt(currentPosition)
             _currentDeckCards.value = updatedCards


### PR DESCRIPTION
## Summary
- show deck description and counts in new `DeckInfoPanel`
- compute learned card count in view model
- remove description and card count from deck list items
- add `DECK_INFO_PANEL` tag and integrate panel in `CardPanel`
- update Compose UI tests to match new layout

## Testing
- `./gradlew :composeApp:build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6846679cf56083329cc730306ca96e5e