### PR TITLE
Show cards from nested decks

### DIFF
--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -83,9 +83,10 @@ fun CardPanel(modifier: Modifier = Modifier) {
     val editFrontFocusRequester = remember { FocusRequester() }
 
     val currentDeck = cardViewModel.currentDeck.collectAsStateWithLifecycle()
-    val hasCards = remember(currentDeck.value?.value) {
+    val currentCards = cardViewModel.currentDeckCards.collectAsStateWithLifecycle()
+    val hasCards = remember(currentCards.value) {
         derivedStateOf {
-            (currentDeck.value?.value?.cardCount ?: 0) > 0
+            currentCards.value.isNotEmpty()
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/CardPanel.kt
@@ -91,6 +91,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
     }
 
     val learnedCardCount = cardViewModel.learnedCardCount.collectAsStateWithLifecycle()
+    val totalCardCount = cardViewModel.totalCardCount.collectAsStateWithLifecycle()
 
     // Only request focus when we have cards or there's a deck selected
     LaunchedEffect(
@@ -344,6 +345,7 @@ fun CardPanel(modifier: Modifier = Modifier) {
         currentDeck.value?.value?.let { deck ->
             DeckInfoPanel(
                 deck = deck,
+                totalCount = totalCardCount.value,
                 learnedCount = learnedCardCount.value,
                 modifier = Modifier.align(Alignment.BottomCenter)
             )

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/DeckInfoPanel.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import me.forketyfork.welk.domain.Deck
 
 @Composable
-fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) {
+fun DeckInfoPanel(deck: Deck, totalCount: Int, learnedCount: Int, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -29,7 +29,7 @@ fun DeckInfoPanel(deck: Deck, learnedCount: Int, modifier: Modifier = Modifier) 
             Spacer(modifier = Modifier.height(4.dp))
         }
         Text(
-            "${deck.cardCount} cards, $learnedCount learned",
+            "$totalCount cards, $learnedCount learned",
             style = MaterialTheme.typography.caption,
             color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
         )

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
@@ -16,6 +16,7 @@ interface CardViewModel : InitializableViewModel {
     val isNewCard: StateFlow<Boolean>
     val isDeleteConfirmationShowing: StateFlow<Boolean>
     val learnedCardCount: StateFlow<Int>
+    val totalCardCount: StateFlow<Int>
     val expandedDeckIds: StateFlow<Set<String>>
 
     fun flipCard()

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/CardViewModel.kt
@@ -12,6 +12,7 @@ interface CardViewModel : InitializableViewModel {
     val editCardContent: StateFlow<Pair<String, String>>
     val currentDeck: StateFlow<StateFlow<Deck>?>
     val availableDecks: StateFlow<List<StateFlow<Deck>>>
+    val currentDeckCards: StateFlow<List<Card>>
     val isNewCard: StateFlow<Boolean>
     val isDeleteConfirmationShowing: StateFlow<Boolean>
     val learnedCardCount: StateFlow<Int>

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
@@ -37,6 +37,7 @@ open class SharedCardViewModel(
 
     // List of cards in the current deck (cached to avoid repeated Firestore queries)
     private val _currentDeckCards = MutableStateFlow<List<Card>>(emptyList())
+    override val currentDeckCards: StateFlow<List<Card>> = _currentDeckCards.asStateFlow()
 
     override val learnedCardCount: StateFlow<Int> by lazy {
         _currentDeckCards
@@ -84,7 +85,7 @@ open class SharedCardViewModel(
             logger.d { "Current deck changed to ${deck?.value?.name}" }
             if (deck != null) {
                 val deckId = deck.value.id ?: error("Deck ID is null for a persistent deck")
-                _currentDeckCards.value = cardRepository.getCardsByDeckId(deckId)
+                _currentDeckCards.value = getAllCardsForDeck(deckId)
                 // Reset to the first card in the deck
                 _currentCardPosition.value = 0
                 updateCurrentCardFromPosition()
@@ -105,6 +106,24 @@ open class SharedCardViewModel(
 
         val position = _currentCardPosition.value.coerceIn(0, cards.size - 1)
         _currentCard.value = cards.getOrNull(position)
+    }
+
+    /**
+     * Recursively collects all cards for the given deck and its child decks.
+     */
+    private suspend fun getAllCardsForDeck(deckId: String): List<Card> {
+        val cards = mutableListOf<Card>()
+
+        suspend fun gather(id: String) {
+            cards += cardRepository.getCardsByDeckId(id)
+            val children = deckRepository.getChildDecks(id)
+            children.forEach { child ->
+                child.id?.let { gather(it) }
+            }
+        }
+
+        gather(deckId)
+        return cards
     }
 
     /**
@@ -132,7 +151,7 @@ open class SharedCardViewModel(
             _currentDeck.value = deck
 
             // Load cards for this deck
-            val cards = cardRepository.getCardsByDeckId(deckId)
+            val cards = getAllCardsForDeck(deckId)
             logger.d { "Loaded ${cards.size} cards for deck $deckId" }
 
             // Store the cards in our local cache
@@ -433,7 +452,7 @@ open class SharedCardViewModel(
 
                 try {
                     // Get the fresh cards list from the repository
-                    val freshCards = cardRepository.getCardsByDeckId(deckId)
+                    val freshCards = getAllCardsForDeck(deckId)
                     logger.d { "Loaded ${freshCards.size} cards for current deck" }
 
                     // Update the list of cards

--- a/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/forketyfork/welk/vm/SharedCardViewModel.kt
@@ -45,6 +45,12 @@ open class SharedCardViewModel(
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
     }
 
+    override val totalCardCount: StateFlow<Int> by lazy {
+        _currentDeckCards
+            .map { cards -> cards.size }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
+    }
+
     private val _isFlipped = MutableStateFlow(false)
     override val isFlipped: StateFlow<Boolean> = _isFlipped.asStateFlow()
 


### PR DESCRIPTION
## Summary
- expose `currentDeckCards` on `CardViewModel`
- load cards recursively from nested decks in `SharedCardViewModel`
- update `CardPanel` to rely on `currentDeckCards`

## Testing
- `./gradlew :composeApp:build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6848a44704ec8332a5db61541796c77d