### PR TITLE
Make side panel resizable

### DIFF
--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/App.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/App.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material.MaterialTheme
@@ -33,6 +33,7 @@ fun App(module: Module = appModule) {
 
         // userId is null if the user is not logged in
         val userId = loginViewModel.userId.collectAsStateWithLifecycle()
+        var sidePanelWidth by remember { mutableStateOf(250) }
 
         AppTheme {
             if (userId.value == null) {
@@ -55,10 +56,11 @@ fun App(module: Module = appModule) {
                 ) {
                     // Use Row for the layout
                     Row(modifier = Modifier.fillMaxSize()) {
-                        // Left panel with the app name and deck list with fixed width
+                        // Left panel with the app name and deck list
                         SidePanel(
-                            // Fixed width instead of weight
-                            modifier = Modifier.zIndex(10f) // Higher z-index to stay on top
+                            width = sidePanelWidth,
+                            modifier = Modifier.zIndex(10f), // Keep above other content
+                            onWidthChange = { sidePanelWidth = it }
                         )
 
                         // Spacer to push the card panel to the center

--- a/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
+++ b/composeApp/src/desktopMain/kotlin/me/forketyfork/welk/components/SidePanel.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
@@ -31,6 +34,7 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 fun SidePanel(
     width: Int = 250,
     modifier: Modifier = Modifier,
+    onWidthChange: (Int) -> Unit = {},
 ) {
 
     val loginViewModel = koinViewModel<DesktopLoginViewModel>()
@@ -291,6 +295,24 @@ fun SidePanel(
                 )
             }
         }
+
+        // Draggable handle to resize the panel
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .width(4.dp)
+                .draggable(
+                    orientation = Orientation.Horizontal,
+                    state = rememberDraggableState { delta ->
+                        val newWidth = (width + delta).toInt().coerceIn(150, 500)
+                        if (newWidth != width) {
+                            onWidthChange(newWidth)
+                        }
+                    }
+                )
+                .background(MaterialTheme.colors.onSurface.copy(alpha = 0.12f))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- allow adjusting side panel width via drag handle
- keep width in `App` state so handle updates layout

## Testing
- `./gradlew :composeApp:build` *(fails: java.lang.NoClassDefFoundError in desktop tests)*

------
https://chatgpt.com/codex/tasks/task_b_68850c0549cc833287470534bcd1a052