### PR TITLE
Apply repository rules: add LICENSE, update workflows, and improve RE…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           echo "$FIREBASE_PROPERTIES_CONTENT" > ./shared/src/jvmMain/resources/firebase.properties
 
       - name: Assemble Desktop App
-        run: ./gradlew :composeApp:assemble
+        run: ./gradlew :composeApp:assemble --warning-mode fail
 
       - name: Run Desktop Tests
         env:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 forketyfork
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # welk
 
+[![Build status](https://github.com/forketyfork/welk/actions/workflows/build.yml/badge.svg)](https://github.com/forketyfork/welk/actions/workflows/build.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Kotlin](https://img.shields.io/badge/language-Kotlin-purple.svg)](https://kotlinlang.org/)
+
 ## About
 
 welk is a cross-platform flashcard application written in Compose Multiplatform, currently in development. 


### PR DESCRIPTION
…ADME

- Rename desktopBuildAndTest.yml to build.yml as per standard naming
- Add --warning-mode fail to Gradle build for stricter builds
- Add MIT LICENSE file with 2025 copyright
- Add build status, license, and language badges to README
- Update repository description and topics via gh command